### PR TITLE
First attempt at tomlifying `tox`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,25 +140,30 @@ overrides."tool.coverage.paths.source".inline_arrays = false
 overrides."tool.ruff.lint.isort.section-order".inline_arrays = false
 
 [tool.tox]
-legacy_tox_ini = """
-    [gh-actions]
-    python =
-        3.10: py310
-        3.11: py311
-        3.12: py312
-
-    [gh-actions:env]
-    OS =
-        ubuntu-latest: linux
-        macos-latest: macos
-        windows-latest: windows
-
-    [testenv]
-    commands =
-        pytest --cov --cov-report=lcov
-    deps =
-        pytest-cov
-
-    [tox]
-    env_list = py{310,311,312}-{linux,macos,windows}
-"""
+env_list = [
+    "py310-linux",
+    "py310-macos",
+    "py310-windows",
+    "py311-linux",
+    "py311-macos",
+    "py311-windows",
+    "py312-linux",
+    "py312-macos",
+    "py312-windows",
+]
+gh-actions.python = [
+    "3.10: py310",
+    "3.11: py311",
+    "3.12: py312",
+]
+gh-actions.env.OS = [
+    "macos-latest: macos",
+    "ubuntu-latest: linux",
+    "windows-latest: windows",
+]
+testenv.commands = [
+    "pytest --cov --cov-report=lcov",
+]
+testenv.deps = [
+    "pytest-cov",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,19 +151,21 @@ env_list = [
     "py312-macos",
     "py312-windows",
 ]
-gh-actions.python = [
-    "3.10: py310",
-    "3.11: py311",
-    "3.12: py312",
-]
-gh-actions.env.OS = [
-    "macos-latest: macos",
-    "ubuntu-latest: linux",
-    "windows-latest: windows",
-]
-testenv.commands = [
+legacy_tox_ini = """
+    [gh-actions]
+    python =
+        3.10: py310
+        3.11: py311
+        3.12: py312
+
+    [gh-actions:env]
+    OS =
+        ubuntu-latest: linux
+        macos-latest: macos
+        windows-latest: windows
+"""
+env.testenv = {commands = [
     "pytest --cov --cov-report=lcov",
-]
-testenv.deps = [
+], deps = [
     "pytest-cov",
-]
+]}


### PR DESCRIPTION
Following https://github.com/tox-dev/tox/pull/3353 there is now full native TOML support for `tox`