### PR TITLE
Revert "Remove `env`, missed in #173"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,7 @@ legacy_tox_ini = """
         macos-latest: macos
         windows-latest: windows
 """
-testenv = {commands = [
+env.testenv = {commands = [
     "pytest --cov --cov-report=lcov",
 ], deps = [
     "pytest-cov",


### PR DESCRIPTION
Reverts paddyroddy/python-template#174