### PR TITLE
Drop `3.10` and add `3.13` Python support

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,4 +20,4 @@ jobs:
       - uses: paddyroddy/.github/actions/python/deployment@f2115592179eb43cf106eeb181adcd003d4cba41 # v0
         with:
           pyproject-toml: ./pyproject.toml
-          python-version: "3.12"
+          python-version: "3.13"

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -20,5 +20,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           project-directory: ./src/example
           pyproject-toml: ./pyproject.toml
-          python-version: "3.12"
+          python-version: "3.13"
           template-directory: ./documentation

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,9 +26,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
     steps:
       # yamllint disable-line rule:line-length
       - uses: paddyroddy/.github/actions/python/tox@f2115592179eb43cf106eeb181adcd003d4cba41 # v0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,5 +159,5 @@ legacy_tox_ini = """
         pytest-cov
 
     [tox]
-    env_list = py{310,311,312}-{linux,macos,windows}
+    env_list = py{311,312}-{linux,macos,windows}
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,9 @@ classifiers = [
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
 dependencies = []
@@ -40,7 +39,7 @@ optional-dependencies = {dev = [
     "pdoc3",
 ]}
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 urls = {Code = """\
     https://github.com/paddyroddy/python-template\
     """, Documentation = """\
@@ -143,9 +142,9 @@ overrides."tool.ruff.lint.isort.section-order".inline_arrays = false
 legacy_tox_ini = """
     [gh-actions]
     python =
-        3.10: py310
         3.11: py311
         3.12: py312
+        3.13: py313
 
     [gh-actions:env]
     OS =


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.13.html
https://scientific-python.org/specs/spec-0000/#2024---quarter-4