### PR TITLE
Use `ruff` to format markdown files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/paddyroddy/.github
-    rev: v0.395.0
+    rev: v0.409.0
     hooks:
       - id: general-hooks
       - id: python-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,8 @@ force-exclude = true
 src = [
     "src",
 ]
+format.docstring-code-format = true
+format.preview = true
 lint.ignore = [
     "COM812",
     "D203",


### PR DESCRIPTION
Following merge of astral-sh/ruff#23434